### PR TITLE
change related to new e107 version #19

### DIFF
--- a/lgsl_files/lgsl_class.php
+++ b/lgsl_files/lgsl_class.php
@@ -25,7 +25,7 @@
     switch($lgsl_config['cms'])
     {
       case "e107":
-        $link = $s ? e_PLUGIN."lgsl/{$index}?s={$s}" : e_PLUGIN."lgsl/{$index}";
+        $link = $s ? e_PLUGIN_ABS."lgsl/{$index}?s={$s}" : e_PLUGIN_ABS."lgsl/{$index}";
       break;
 
       case "joomla":


### PR DESCRIPTION
the old version doesn't work with PHP 7, so they will not use this version and new e107 version uses SEF-URLs, so paths have to be absolute