### PR TITLE
Tiny bad total count centering fix on classic style on "old" browsers

### DIFF
--- a/lgsl_files/styles/classic_style.css
+++ b/lgsl_files/styles/classic_style.css
@@ -123,7 +123,7 @@ div.servername_link {display: none;}
 #pages a {padding: 5px; background-color: #c6c6c6; font-size: 1.3em;}
 #pages span {padding: 10px;}
 
-#totals {width: fit-content; margin:auto; margin-top: 16px;}
+#totals {width: fit-content; margin:auto; margin-top: 16px; text-align:center;}
 #totals > div {width: fit-content;  background-color: #e4eaf2; padding:4px; display:inline-block;}
 
 /* */


### PR DESCRIPTION
Like here on SeaMonkey

![imagen](https://github.com/user-attachments/assets/13996cf7-23fd-412e-8ead-2061645e8be5)
![imagen](https://github.com/user-attachments/assets/0a7399bf-fe93-4fcc-ae25-ebd9e85d8170)

Dunno about other styles tho