### PR TITLE
Fix wrong maxplayers for RTCWCoop servers

### DIFF
--- a/lgsl_files/lgsl_protocol.php
+++ b/lgsl_files/lgsl_protocol.php
@@ -856,8 +856,11 @@
     $server['s']['players'] = empty($part['2']) ? 0 : count($part) - 2;
 
     if (isset($server['e']['maxclients']))    { $server['s']['playersmax'] = $server['e']['maxclients']; }    // QUAKE 2
-    if (isset($server['e']['sv_maxclients'])) { $server['s']['playersmax'] = $server['e']['sv_maxclients']; }
-
+    if ($server['b']['type'] == "wolfrtcw" && isset($server['e']['sv_maxcoopclients'])) {                     // RTCWCOOP FIX
+        $server['s']['playersmax'] = $server['e']['sv_maxcoopclients'];
+    } else if (isset($server['e']['sv_maxclients'])) {                                                        // GENERIC
+        $server['s']['playersmax'] = $server['e']['sv_maxclients'];
+    }
     if (isset($server['e']['pswrd']))      { $server['s']['password'] = $server['e']['pswrd']; }              // CALL OF DUTY
     if (isset($server['e']['needpass']))   { $server['s']['password'] = $server['e']['needpass']; }           // QUAKE 2
     if (isset($server['e']['g_needpass'])) { $server['s']['password'] = (int)$server['e']['g_needpass']; }


### PR DESCRIPTION
I tried to put this as a single line instead of just doing that ifelse, but it seems that PHP ignores it and continues to use sv_maxclients (in this mod for some reason sv_maxcoopclients is used, which causes it to incorrectly display 128 as maxplayers).

<img width="574" height="45" alt="imagen" src="https://github.com/user-attachments/assets/d7228960-69c6-4ebc-ae83-4e64957487df" />
<img width="567" height="46" alt="imagen" src="https://github.com/user-attachments/assets/5953e248-56e2-43bd-b1bb-89d914b0552c" />
